### PR TITLE
Bugfix: webhook fix and Enum revert

### DIFF
--- a/src/Client/Webhook/Webhooks.php
+++ b/src/Client/Webhook/Webhooks.php
@@ -39,7 +39,7 @@ class Webhooks
         return $this->httpClient
             ->when($this->basicAuth,
                 fn ($request) => $request->withBasicAuth($this->basicAuth['username'], $this->basicAuth['password']))
-            ->{$this->method}($path, $data)
+            ->{$this->method->value}($path, $data)
             ->json();
     }
 

--- a/tests/Unit/Client/Webhook/WebhooksTest.php
+++ b/tests/Unit/Client/Webhook/WebhooksTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use KayedSpace\N8n\Facades\N8nClient;
+
+it('send webhook request', function () {
+    $url = Config::get('n8n.webhook.base_url');
+
+    Http::fake(fn () => Http::response(['ok' => true], 200));
+
+    N8nClient::webhooks()->request('/path-to-your-webhook');
+
+    Http::assertSent(fn (Request $req) => "$url/path-to-your-webhook" === $req->url());
+});


### PR DESCRIPTION
Don't **merge** for now as the **WebhookTest** added is failing ❌

The test fails because this `"$url/webhook" === $req->url()` is false

and their values in the test:
`$url/webhook` = `http://localhost:5678/api/v1/webhook`
`$req->url()` = `http://localhost:5678/webhook/`

---

The values of the **Enum** are used to call Http Request methods: `get(), post()...`